### PR TITLE
Changing import statements for MASTIFF plugins to work with latest MASTIFF version.

### DIFF
--- a/mastiff-plugins/Office-officedissector-embedded-code.py
+++ b/mastiff-plugins/Office-officedissector-embedded-code.py
@@ -21,7 +21,7 @@ import os
 
 from zipfile import BadZipfile
 
-import mastiff.category.office as office
+import mastiff.plugins.category.office as office
 import officedissector
 
 class OfficeDissectorSkel(office.OfficeCat):

--- a/mastiff-plugins/Office-officedissector-multimedia.py
+++ b/mastiff-plugins/Office-officedissector-multimedia.py
@@ -22,7 +22,7 @@ import os
 
 from zipfile import BadZipfile
 
-import mastiff.category.office as office
+import mastiff.plugins.category.office as office
 import officedissector
 
 class OfficeDissectorSkel(office.OfficeCat):

--- a/mastiff-plugins/Office-officedissector-skel.py
+++ b/mastiff-plugins/Office-officedissector-skel.py
@@ -38,7 +38,7 @@ import os
 
 from zipfile import BadZipfile
 
-import mastiff.category.office as office
+import mastiff.plugins.category.office as office
 import officedissector
 
 class OfficeDissectorSkel(office.OfficeCat):

--- a/mastiff-plugins/Office-officedissector-urls.py
+++ b/mastiff-plugins/Office-officedissector-urls.py
@@ -18,7 +18,7 @@ import os
 
 from zipfile import BadZipfile
 
-import mastiff.category.office as office
+import mastiff.plugins.category.office as office
 import officedissector
 
 class OfficeDissectorSkel(office.OfficeCat):


### PR DESCRIPTION
The original officedissector MASTIFF plugins were written for 0.6.0, which is the latest stable version. The latest dev versions, however, have slightly modified the location of the category plugins that are imported. This will fix that.
