### PR TITLE
Remove assert and set the content type to empty string

### DIFF
--- a/officedissector/part.py
+++ b/officedissector/part.py
@@ -117,9 +117,11 @@ class Part(object):
                           self.name.rsplit('.', 1)[1].strip('.') +
                           '"]/@ContentType')
             result2 = content_types.xpath(xpath_qry2, ct_nsmap)
-            # When this second XPath result is also empty, this Part has no content_type
-            assert len(result2), 'content_type of Part is empty: %r' % self
-            self.__content_type = result2[0]
+            if not result2:
+                # When this second XPath result is also empty, this Part has no content_type
+                self.__content_type = ''
+            else:
+                self.__content_type = result2[0]
 
         return self.__content_type
 

--- a/test/unit_test/test_officedissector.py
+++ b/test/unit_test/test_officedissector.py
@@ -273,9 +273,10 @@ class PackageTest(unittest.TestCase):
             Document('testdocs/bad_extension.doc')
             self.assertEqual(self.test_stdout.getvalue(),
                              'File extension is not an OOXML file type')
-        with self.assertRaisesRegexp(AssertionError,
-                                     'content_type of Part is empty'):
-            Document('testdocs/missing_content_type.docx')
+        # Skip this test: The document doesn't follow the spec, but is still openable
+        # with self.assertRaisesRegexp(AssertionError,
+        #                             'content_type of Part is empty'):
+        #    Document('testdocs/missing_content_type.docx')
         with self.assertRaises(KeyError):
             Document('testdocs/missing_part.docx')
             self.assertEqual(self.test_stdout.getvalue(),


### PR DESCRIPTION
Other fix for https://github.com/grierforensics/officedissector/issues/5, more generic.

The content type doesn't seems to be used anywhere else in the code so I don't see it as a security issue. 
